### PR TITLE
Add files via upload

### DIFF
--- a/kubernetes_manifests/mychart/Chart.yaml
+++ b/kubernetes_manifests/mychart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mychart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/kubernetes_manifests/mychart/templates/configmap.yaml
+++ b/kubernetes_manifests/mychart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mychart-configmap
+data:
+  myvalue: "Hello World"

--- a/kubernetes_manifests/mychart/templates/service.yaml
+++ b/kubernetes_manifests/mychart/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-service
+spec:
+  selector:
+    app: online-inference
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/kubernetes_manifests/mychart/values.yaml
+++ b/kubernetes_manifests/mychart/values.yaml
@@ -1,0 +1,82 @@
+# Default values for mychart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/kubernetes_manifests/online-inference-deployment-blue-green.yaml
+++ b/kubernetes_manifests/online-inference-deployment-blue-green.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 8
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0%
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: liliyamakhmutova/online_inference:v2
+          name: online-inference
+          ports:
+            - containerPort: 8000          

--- a/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
+++ b/kubernetes_manifests/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 4
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 50%
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: liliyamakhmutova/online_inference:v2
+          name: online-inference
+          ports:
+            - containerPort: 8000          

--- a/kubernetes_manifests/online-inference-pod-probes.yaml
+++ b/kubernetes_manifests/online-inference-pod-probes.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: liliyamakhmutova/online_inference:v2
+      name: online-inference
+      ports:
+        - containerPort: 8000
+      readinessProbe:
+        httpGet:
+          path: /healz
+          port: 8000
+        initialDelaySeconds: 15
+        periodSeconds: 3
+      livenessProbe:
+            httpGet:
+                path: /healz
+                port: 8000            
+            initialDelaySeconds: 30
+            periodSeconds: 3

--- a/kubernetes_manifests/online-inference-pod-resources.yaml
+++ b/kubernetes_manifests/online-inference-pod-resources.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: liliyamakhmutova/online_inference:v1
+      name: online-inference
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+            memory: "512Mi"
+            cpu: 0.5
+        limits:
+            memory: "1Gi"
+            cpu: 1

--- a/kubernetes_manifests/online-inference-pod.yaml
+++ b/kubernetes_manifests/online-inference-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: liliyamakhmutova/online_inference:v1
+      name: online-inference
+      ports:
+        - containerPort: 8000

--- a/kubernetes_manifests/online-inference-replicaset.yaml
+++ b/kubernetes_manifests/online-inference-replicaset.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: liliyamakhmutova/online_inference:v2
+          name: online-inference
+          ports:
+            - containerPort: 8000
+
+
+
+
+          

--- a/kubernetes_manifests/online-inference-service.yaml
+++ b/kubernetes_manifests/online-inference-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-service
+spec:
+  selector:
+    app: fastapi-ml
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000


### PR DESCRIPTION
Самооценка:
1) Развернула kubernetes (выбрала способ с https://minikube.sigs.k8s.io/docs/start/).
Работает:
kubectl cluster-info
Kubernetes master is running at https://127.0.0.1:15267
KubeDNS is running at https://127.0.0.1:15267/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

Использую также утилиту Lens для удобства.
(5 баллов)

2) Написала простой pod manifests online-inference-pod.yaml 
Все поднялось, скриншот прилагаю
(4 балла)

2а) Прописала requests/limits в online-inference-pod-resources.yaml. Устанавливала локально на довольно слабый комп, плюс у моего приложения стоят ограничения на размер запроса, поэтому ресурсы запросила скромные: 

requests:
	memory: "512Mi"
	cpu: 0.5
limits:
	memory: "1Gi"
	cpu: 1
	
(2 балл)

3) Модифицируйте свое приложение так, чтобы оно стартовало не сразу(с задержкой секунд 20-30) и падало спустя минуты работы. Добавьте liveness и readiness пробы , посмотрите что будет происходить. Напишите в описании -- чего вы этим добились. Закоммититьте отдельный манифест online-inference-pod-probes.yaml (и изменение кода приложения). Опубликуйте ваше приложение(из ДЗ 2) с тэгом v2.

Реализовала следующим образом: добавила задержку в on_event("startup"), при запросе healz более 10-ти раз сервер падает: 

@app.get("/healz")
def health() -> bool:
    global requests_count
    if requests_count > 10:
        sys.exit("Too many requests!!!")
    requests_count += 1
    return not (model is False)
Опубликовала с тегом v2:  liliyamakhmutova/online_inference:v2
1. Pod реально запускается после запуска сервера (readiness).
2. Далее идут запросы, ничего не падает, хотя внутри приложения происходит sys.exit(). Запросы идут к разным портам, притом перезапуска не происходит:
INFO: Started server process [1]
INFO: Waiting for application startup.
INFO: Application startup complete.
INFO: Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO: 172.17.0.1:43562 - "GET /healz HTTP/1.1" 200 OK
INFO: 172.17.0.1:43582 - "GET /healz HTTP/1.1" 200 OK
INFO: 172.17.0.1:43600 - "GET /healz HTTP/1.1" 200 OK
INFO: 172.17.0.1:43608 - "GET /healz HTTP/1.1" 200 OK
INFO: 172.17.0.1:43618 - "GET /healz HTTP/1.1" 200 OK
INFO: 172.17.0.1:43626 - "GET /healz HTTP/1.1" 200 OK
INFO: 172.17.0.1:43642 - "GET /healz HTTP/1.1" 200 OK
(3 балла)

4) Создайте replicaset, сделайте 3 реплики вашего приложения. (https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)
Ответьте на вопрос, что будет, если сменить докер образа в манифесте и одновременно с этим 
а) уменьшить число реплик
б) увеличить число реплик.
Поды с какими версиями образа будут внутри будут в кластере?
Закоммитьте online-inference-replicaset.yaml


Что получилось: 
1) при уменьшении: версия внутри ReplicaSet поменялась, а внутри Pod — нет, но количество уменьшилось (до 1)
2) при увеличении: версия ReplicaSet поменялась, внутри Pod версия двух новых добавленных — поменялась, а у старых 3-х не поменялась. Количество увеличилось (до 5)

(3 балла)

5) Опишите деплоймент для вашего приложения.  (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
Играя с параметрами деплоя(maxSurge, maxUnavaliable), добейтесь ситуации, когда при деплое новой версии 
a) Есть момент времени, когда на кластере есть как все старые поды, так и все новые (опишите эту ситуацию) (закоммититьте файл online-inference-deployment-blue-green.yaml)
б) одновременно с поднятием новых версии, гасятся старые (закоммитите файл online-inference-deployment-rolling-update.yaml)


Как добилась: 
а) rollingUpdate:
      maxSurge: 100%
      maxUnavailable: 0%
б) rollingUpdate:
      maxSurge: 50%
      maxUnavailable: 50%

(3 балла)


Бонусные активности:
Установить helm и оформить helm chart, включить в состав чарта ConfigMap и Service. -- 5 баллов

Установила helm, добавила все (mychart) как в инструкции  https://helm.sh/docs/chart_template_guide/getting_started/, если все верно поняла. Скриншоты прилагаю.




Итого: 25 баллов, если все действительно правильно реализовано.


![lens_resources](https://user-images.githubusercontent.com/71342102/122771225-ab551b00-d2bf-11eb-9434-d5a97c2e65e1.png)
![online_inference_browser](https://user-images.githubusercontent.com/71342102/122771227-ac864800-d2bf-11eb-8eaa-c2d7d6ac528c.PNG)
![online_inference_lens](https://user-images.githubusercontent.com/71342102/122771230-ad1ede80-d2bf-11eb-8749-3ff142455637.PNG)
![replicaset_init](https://user-images.githubusercontent.com/71342102/122771232-ad1ede80-d2bf-11eb-9284-b428e87f8444.PNG)
![replicaset_init_rep](https://user-images.githubusercontent.com/71342102/122771240-af813880-d2bf-11eb-8526-d57f0a1824ef.PNG)
![replicaset_less_pod](https://user-images.githubusercontent.com/71342102/122771241-af813880-d2bf-11eb-96cf-26c49b67c06f.PNG)
![replicaset_less_pod_image](https://user-images.githubusercontent.com/71342102/122771244-b019cf00-d2bf-11eb-910d-b4b45e0ee1a7.PNG)
![replicaset_less_replicaset_image](https://user-images.githubusercontent.com/71342102/122771249-b0b26580-d2bf-11eb-80af-42588aa3598a.PNG)
![replicaset_more_pod](https://user-images.githubusercontent.com/71342102/122771255-b1e39280-d2bf-11eb-8c61-36d73a481451.PNG)
![replicaset_more_pod_v1](https://user-images.githubusercontent.com/71342102/122771260-b1e39280-d2bf-11eb-913d-cbaf23de99c5.PNG)
![replicaset_more_pod_v2](https://user-images.githubusercontent.com/71342102/122771263-b314bf80-d2bf-11eb-92b1-2a34e7ace8cc.PNG)
![helm](https://user-images.githubusercontent.com/71342102/122771267-b3ad5600-d2bf-11eb-920d-ee3cd67b89b0.PNG)
![helm2](https://user-images.githubusercontent.com/71342102/122771275-b445ec80-d2bf-11eb-8ba6-3b248a1d0242.PNG)
te